### PR TITLE
changed variable name for parameters in update function

### DIFF
--- a/src/Yosymfony/Spress/Composer/Installer/Installer.php
+++ b/src/Yosymfony/Spress/Composer/Installer/Installer.php
@@ -75,7 +75,7 @@ class Installer extends LibraryInstaller
     /**
      * {@inheritDoc}
      */
-    public function update(InstalledRepositoryInterface $repo, PackageInterface $initial, PackageInterface $target)
+    public function update(InstalledRepositoryInterface $repo, PackageInterface $initial, PackageInterface $package)
     {
         if ($this->isInstallFromSpressRoot() && self::TYPE_PLUGIN === $package->getType()) {
             return;


### PR DESCRIPTION
In the Installer.php file, there is a function called update.  In the parameters, there is a requirement for a PackageInterface object, and it is given the variable $target.  When used in the function, it is called $package.  I changed the parameter variable to $package.  Tests run smoothly.
